### PR TITLE
Addition of hs_name and hs_id to profile_update custom fields.

### DIFF
--- a/src/MBC_RegistrationMobile_Service_MobileCommons.php
+++ b/src/MBC_RegistrationMobile_Service_MobileCommons.php
@@ -82,10 +82,10 @@ class  MBC_RegistrationMobile_Service_MobileCommons extends MBC_RegistrationMobi
     }
 
     // AfterSchool user import
-    if (isset($message['hs_name'])) {
+    if (isset($message['original']['hs_name'])) {
       $this->message['hs_name'] = $message['original']['hs_name'];
     }
-    if (isset($message['hs_id'])) {
+    if (isset($message['original']['hs_id'])) {
       $this->message['hs_id'] = $message['original']['hs_id'];
     }
   }

--- a/src/MBC_RegistrationMobile_Service_MobileCommons.php
+++ b/src/MBC_RegistrationMobile_Service_MobileCommons.php
@@ -81,6 +81,13 @@ class  MBC_RegistrationMobile_Service_MobileCommons extends MBC_RegistrationMobi
       $this->message['CGG2015_1st_vote'] = $message['original']['candidate_name'];
     }
 
+    // AfterSchool user import
+    if (isset($message['hs_name'])) {
+      $this->message['hs_name'] = $message['original']['hs_name'];
+    }
+    if (isset($message['hs_id'])) {
+      $this->message['hs_id'] = $message['original']['hs_id'];
+    }
   }
 
   /**


### PR DESCRIPTION
Fixes #27 

Addition of:
- `hs_name`
- `hs_id` 
as values submitted to Mobile Commons `profile_update()`. High school values for a user are supplied by After School user imports but the fields could be used by any call to `profile_update` via the Mobile Commons API.

**To test**:
- test runs of `mbp-user-import` -> `mbc-user-import` will produce a message sent to `mbc-registration-mobile`. Messages with the `hs_name` and `hs_id` values will be set in the Mobile Commons user profile by mobile number.

**Related**:
- https://github.com/DoSomething/mbp-user-import/pull/37
- https://github.com/DoSomething/mbc-user-import/issues/51