### PR TITLE
Add afterschool_optin to submititon values

### DIFF
--- a/src/MBC_RegistrationMobile_Service_MobileCommons.php
+++ b/src/MBC_RegistrationMobile_Service_MobileCommons.php
@@ -88,6 +88,9 @@ class  MBC_RegistrationMobile_Service_MobileCommons extends MBC_RegistrationMobi
     if (isset($message['original']['hs_id'])) {
       $this->message['hs_id'] = $message['original']['hs_id'];
     }
+    if (isset($message['original']['optin'])) {
+      $this->message['afterschool_optin'] = $message['original']['optin'];
+    }
   }
 
   /**

--- a/src/MBC_RegistrationMobile_Service_MobileCommons.php
+++ b/src/MBC_RegistrationMobile_Service_MobileCommons.php
@@ -88,8 +88,8 @@ class  MBC_RegistrationMobile_Service_MobileCommons extends MBC_RegistrationMobi
     if (isset($message['original']['hs_id'])) {
       $this->message['hs_id'] = $message['original']['hs_id'];
     }
-    if (isset($message['original']['optin'])) {
-      $this->message['afterschool_optin'] = $message['original']['optin'];
+    if (isset($message['original']['afterschool_optin'])) {
+      $this->message['afterschool_optin'] = $message['original']['afterschool_optin'];
     }
   }
 


### PR DESCRIPTION
Fixes #29 

Users imported from After School via `mbp-user-import` have an `optin` data value. Include this value when submitting a `profile_update` to Mobile Commons.
- Add `afterschool_optin` to values included in submisison values `SOLO` (`SINGLE_OPT_IN)` or `PAIR` (`DOUBLE_OPT_IN`): https://github.com/DoSomething/mbc-registration-mobile/blob/master/src/MBC_RegistrationMobile_Service_MobileCommons.php#L84-L90
- Add `afterschool_optin` to user profile custom fields in Mobile Commons.


**Related**: All issues will be deployed together.
- https://github.com/DoSomething/mbc-user-import/issues/53
- https://github.com/DoSomething/mbp-user-import/issues/38