### PR TITLE
After School incident 160730

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,9 +14,9 @@
   ],
   "require": {
     "php": ">= 5.3.0",
-    "DoSomething/messagebroker-phplib": "0.2.*",
-    "dosomething/mb-toolbox": "0.11.*",
-    "dosomething/stathat": "1.*",
+    "DoSomething/messagebroker-phplib": "0.3.*",
+    "dosomething/mb-toolbox": "0.12.*",
+    "dosomething/stathat": "2.*",
     "dosomething/mobilecommons-php": "1.0.*"
   },
   "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
   "name": "mbc-registration-mobile",
   "type": "project",
-  "version": "0.3.1",
+  "version": "0.4.0",
   "description": "A consumer application for the Message Broker system that consumes entries on the mobileCommonsQueue. Entries will produce new or update user accounts in Mobile Commons. Support for various affiliates will result in interfacing with the appropreate affiliate service / account.",
   "keywords": ["message broker", "Drupal", "SMS"],
   "homepage": "https://github.com/DoSomething/mbc-registration-mobile",

--- a/mbc-registration-mobile.config.inc
+++ b/mbc-registration-mobile.config.inc
@@ -3,6 +3,7 @@
  * Message Broker configuration settings for mbc-registration-mobile
  */
 
+use DoSomething\MessageBroker\MessageBroker;
 use DoSomething\MB_Toolbox\MB_Configuration;
 use DoSomething\StatHat\Client as StatHat;
 use DoSomething\MB_Toolbox\MB_Toolbox;

--- a/mbc-registration-mobile.php
+++ b/mbc-registration-mobile.php
@@ -6,7 +6,7 @@
  * transactionalExchange. The mbp-registration-mobile application produces user
  * entries in Mobile Commons based the contents of the queue.
  */
-    
+
 use DoSomething\MBC_RegistrationMobile\MBC_RegistrationMobile_Consumer;
 
 date_default_timezone_set('America/New_York');
@@ -36,7 +36,7 @@ require_once __DIR__ . '/mbc-registration-mobile.config.inc';
 // Kick off - block, wait for messages in queue
 echo '------- mbc-registration-mobile START - ' . date('j D M Y G:i:s T') . ' -------', PHP_EOL;
 $mb = $mbConfig->getProperty('messageBroker');
-$mb->consumeMessage(array(new MBC_RegistrationMobile_Consumer(), 'consumeRegistrationMobileQueue'), QOS_SIZE);
+$mb->consume(array(new MBC_RegistrationMobile_Consumer(), 'consumeRegistrationMobileQueue'), QOS_SIZE);
 echo '------- mbc-registration-mobile END - ' . date('j D M Y G:i:s T') . ' -------', PHP_EOL;
     
 /**


### PR DESCRIPTION
The `messagebroker-phplib` repo was updated with breaking changes and not tagged with version number to suggest changes -> `0.2.9` vs `0.3.0`

- Updates to support move to `0.3.* messagebroker-phplib`.