### PR TITLE
Fixes unexpected clogging. Postmortem explanation

### DIFF
--- a/src/MBC_RegistrationMobile_Consumer.php
+++ b/src/MBC_RegistrationMobile_Consumer.php
@@ -88,8 +88,13 @@ class MBC_RegistrationMobile_Consumer extends MB_Toolbox_BaseConsumer
       else {
         echo '- Not timeout or connection error, message to deadLetterQueue: ' . date('j D M Y G:i:s T'), PHP_EOL;
         echo '- Error message: ' . $e->getMessage(), PHP_EOL;
+
+        // Uknown exception, save the message to deadLetter queue.
         $this->statHat->ezCount('mbc-registration-mobile: MBC_RegistrationMobile_Consumer: Exception: deadLetter', 1);
         parent::deadLetter($this->message, 'MBC_RegistrationMobile_Consumer->consumeRegistrationMobileQueue() Error', $e->getMessage());
+
+        // Send Negative Acknowledgment, don't requeue the message.
+        $this->messageBroker->sendNack($this->message['payload'], false, false);
       }
     }
 


### PR DESCRIPTION
#### What's this PR do?
- Permanent fix for a "pipe clogging" bug that broke down our sms messaging for more than 12 hours on September 22
#### Any background context you want to provide?

> "Swamp gas from a weather balloon was trapped in a thermal pocket and reflected the light from Venus." — Men in Black (1997)

This bug is alike. To reproduce it a lot of unrelated things must come together:
1. Rabbit consumer must be configured in [basic QOS mode](https://github.com/DoSomething/mbc-registration-mobile/blob/master/mbc-registration-mobile.php#L17)
2. You'll need a message rejected with an exception that is not a:
   - Connection timed out
   - Operation timed out
   - Connection failure
   - HTTP Code 500
3. Message broker should receive 8 ([`number of routing keys`](https://github.com/sergii-tkachenko/messagebroker-config/blob/8f8684983f9eccdf7739fbd7e795cda9f3747edc/mb_config.json#L98-L99) x `count of of consumer process`) of these messages in a row. Meaning there shouldn't one correct message between them.

For these reason we were good for a while. Turned out there's a [misconfiguration of Canadian users](https://github.com/DoSomething/mbc-registration-mobile/issues/45) routing that generate 8 faulty messages in the middle of the night. This basically clogged MobileCommons queue. The consumer just won't accept any new messages until it gets unclogged.

I checked ALL other consumers for similar code flow. Fortunately, only this one was affected.
#### What are the relevant tickets?

Closes #36 
Trello: https://trello.com/c/QbRyUCQQ/64-13-quicksilver-as-a-developer-i-want-to-know-if-consumers-affected-by-bug-caused-by-unknown-error-on-remote-service-instead-of-r

cc @mshmsh5000 @justkika
