### PR TITLE
Fixes environment file load.

### DIFF
--- a/mbc-registration-mobile.php
+++ b/mbc-registration-mobile.php
@@ -71,10 +71,10 @@ function allowedEnviroment($setting)
 function loadConfig() {
 
     // Check that environment config file exists
-    if (!file_exists('environment.php')) {
+    if (!file_exists(__DIR__ . '/environment.php')) {
         return false;
     }
-    include('./environment.php');
+    include(__DIR__ . '/environment.php');
 
     return true;
 }


### PR DESCRIPTION
Because it won't work from init script otherwise:

```
    exec sudo -u dosomething /usr/bin/php /var/www/mb-php/mbc-registration-mobile/mbc-registration-mobile.php >> /var/log/mb-php/mbc-registration-mobile/mbc-registration-mobile.log 2>&1
```

cc @aaronschachter 