### PR TITLE
Extend process on Gambit logic.

### DIFF
--- a/src/MBC_RegistrationMobile_Service_MobileCommons.php
+++ b/src/MBC_RegistrationMobile_Service_MobileCommons.php
@@ -265,7 +265,27 @@ class  MBC_RegistrationMobile_Service_MobileCommons extends MBC_RegistrationMobi
     }
 
     if (empty($gambitCampaign)) {
+      echo '**  Gambit * Incorrect campaign.';
       return false;
+    }
+
+    // If Campaignbot is not enabled for the campaign:
+    if ($gambitCampaign->campaignbot != true) {
+      echo '** Gambit * Campaignbot is not enabled for campaign id '
+        . $campaign_id . ', ignoring.' . PHP_EOL;
+      return false;
+    }
+
+    // Ignore sources.
+    if (!empty($original['source'])) {
+      $ignoredSources = [
+        // Ignore sms signup, those has aleady been processed on Gambit.
+        'sms-mobilecommons',
+      ];
+      if (in_array($original['source'], $ignoredSources)) {
+        echo '** Gambit * Ignore source: ' . $original['source'] . '.' . PHP_EOL;
+        return false;
+      }
     }
 
     // Todo: check id.


### PR DESCRIPTION
#### What's this PR do?
- Don't send signups to Gambit when campaignbot is explicitly disabled for this campaign
- Don't send signups to Gambit when source is `sms-mobilecommons`: these has already been processed

#### Any background context you want to provide?
We need to make sure that opt-in path isn't set to such campaigns, or it will fall back to Mobile Commons processing.

#### What are the relevant tickets?
Fixes #48.
