### PR TITLE
Allow niche imported signups to be processed on Gambit.

### DIFF
--- a/src/MBC_RegistrationMobile_Service_MobileCommons.php
+++ b/src/MBC_RegistrationMobile_Service_MobileCommons.php
@@ -242,7 +242,11 @@ class  MBC_RegistrationMobile_Service_MobileCommons extends MBC_RegistrationMobi
     $original = &$this->message['original'];
 
     // Ignore other activities than signup.
-    if (empty($original['activity']) || $original['activity'] !== 'campaign_signup') {
+    $allowedActivities  = [
+      'campaign_signup',
+      'user_welcome-niche',
+    ];
+    if (empty($original['activity']) || !in_array($original['activity'], $allowedActivities)) {
       return false;
     }
 


### PR DESCRIPTION
Treat `user_welcome-niche` activity as a signup:

```
- MBC_RegistrationMobile_ServiceDirector->serviceFactory() application_id: MUI
** Using Mobile Commons as Service
-> connectServiceObject company_key: CO769E2CADA06F34BED558E5A659CCD371
-> Processing signup on Gambit: sid = 2309295, source = niche
- mobileCommonsQueue ready: 0
- mobileCommonsQueue unacked: 1
```