### PR TITLE
Adds a logic to skip messages with explicitly disalbled transactionals

### DIFF
--- a/src/MBC_RegistrationMobile_Service_MobileCommons.php
+++ b/src/MBC_RegistrationMobile_Service_MobileCommons.php
@@ -66,6 +66,12 @@ class  MBC_RegistrationMobile_Service_MobileCommons extends MBC_RegistrationMobi
       }
     }
 
+    // Skip messages with explicitly disabled transactionals.
+    if (isset($message['original']['transactionals']) && $message['original']['transactionals'] === false) {
+      echo '- canProcess(), transactionals disabled.', PHP_EOL;
+      return false;
+    }
+
     return TRUE;
   }
 


### PR DESCRIPTION
Skip messages the explicitly turned off `transactionals`.
This is a fix for DoSomething/Quicksilver-PHP#82 and DoSomething/mbc-user-import#80.

Error introduced in See DoSomething/phoenix#6534 and DoSomething/phoenix#6439.