### PR TITLE
Reduce gambit request sleep time from .25 to .1 sec

### DIFF
--- a/src/MBC_RegistrationMobile_Service_MobileCommons.php
+++ b/src/MBC_RegistrationMobile_Service_MobileCommons.php
@@ -313,8 +313,8 @@ class  MBC_RegistrationMobile_Service_MobileCommons extends MBC_RegistrationMobi
       . ', source = ' . $signup_source . PHP_EOL;
 
     try {
-      // Sleep for 0.25 sec before hitting Gambit.
-      usleep(250000);
+      // Sleep for 0.1 sec before hitting Gambit.
+      usleep(10000);
       $result = $this->gambit->createSignup($signup_id, $signup_source);
       if ($result) {
         $this->messageBroker->sendAck($payload);


### PR DESCRIPTION
It looks like .25 sec is just taking too much time wait during user imports.
Users are being created slower than we're placing them in messaging groups, which causes the race condition.