### PR TITLE
Fix Gambit Campaign Cache

### DIFF
--- a/mbc-registration-mobile.config.inc
+++ b/mbc-registration-mobile.config.inc
@@ -104,3 +104,18 @@ $gambit = new Gambit([
   'apiKey' => getenv('GAMBIT_API_KEY'),
 ]);
 $mbConfig->setProperty('gambit', $gambit);
+
+echo "Loading Gambit campaigns cache..." . PHP_EOL;
+$gambitCampaigns = $gambit->getAllCampaigns(['campaignbot' => true]);
+$gambitCampaignsCache = [];
+foreach ($gambitCampaigns as $campaign) {
+  if ($campaign->status != 'closed') {
+    $gambitCampaignsCache[$campaign->id] = $campaign;
+  }
+}
+
+if (count($gambitCampaignsCache) < 1) {
+  // Basically, die.
+  throw new Exception('No gambit connection.');
+}
+$mbConfig->setProperty('gambitCampaignsCache', $gambitCampaignsCache);

--- a/src/MBC_RegistrationMobile_Service_MobileCommons.php
+++ b/src/MBC_RegistrationMobile_Service_MobileCommons.php
@@ -41,18 +41,7 @@ class  MBC_RegistrationMobile_Service_MobileCommons extends MBC_RegistrationMobi
 
     // Cache gambit campaigns.
     $this->gambit = $this->mbConfig->getProperty('gambit');
-    $gambitCampaigns = $this->gambit->getAllCampaigns(['campaignbot' => true]);
-
-    foreach ($gambitCampaigns as $campaign) {
-      if ($campaign->status != 'closed') {
-        $this->gambitCampaignsCache[$campaign->id] = $campaign;
-      }
-    }
-
-    if (count($this->gambitCampaignsCache) < 1) {
-      // Basically, die.
-      throw new Exception('No gambit connection.');
-    }
+    $this->gambitCampaignsCache = $this->mbConfig->getProperty('gambitCampaignsCache');
   }
 
   /**


### PR DESCRIPTION
I discovered that `MBC_RegistrationMobile_Service_MobileCommons::construct` is actually executed on each message (bad OOP is bad OOP). To avoid unnecessary requests to Gambit, the cache is moved to the top level.