### PR TITLE
Explicitly ignore user_register activity

### DIFF
--- a/src/MBC_RegistrationMobile_Service_MobileCommons.php
+++ b/src/MBC_RegistrationMobile_Service_MobileCommons.php
@@ -70,7 +70,7 @@ class  MBC_RegistrationMobile_Service_MobileCommons extends MBC_RegistrationMobi
 
     // Ignore activities.
     if (!empty($message['original']['activity'])) {
-      $ignoreActivities = ['campaign_signup_single'];
+      $ignoreActivities = ['campaign_signup_single', 'user_register'];
       if (in_array($message['original']['activity'], $ignoreActivities)) {
         echo 'Ignore activity ' . $message['original']['activity'] . '.' . PHP_EOL;
         return FALSE;


### PR DESCRIPTION
Due to an unknown change in Phoenix, Quicksilver started treating user register messages as they were campaign signup messages and sending them to Mobile Commons. Example:

```
** Consuming mobile: 5555555555 from: US doing: user_register
- MBC_RegistrationMobile_ServiceDirector->serviceFactory() application_id: US
** Using Mobile Commons as Service
-> connectServiceObject company_key: CO769E2CADA06F34BED558E5A659CCD371
** Activity is not one of ["campaign_signup","user_welcome-niche"], found : user_register
** process(): Error sending mobile number: 5555555555 to mobile Mobile Commons service for user signup.
** Operation timed out... waiting before retrying: 5 Tue Sep 2017 10:56:10 EDT - getMessage(): Operation timed out after 30001 milliseconds with 0 bytes received
- Nack sent to requeue message: 5 Tue Sep 2017 10:56:30 EDT

- mobileCommonsQueue ready: 520
- mobileCommonsQueue unacked: 8

------ mbc-registration-mobile - MBC_RegistrationMobile_Consumer->consumeRegistrationMobileQueue() - 5 Tue Sep 2017 10:56:30 EDT END ------
```

This PR is to prevent this behavior while the investigation into the cause is ongoing.